### PR TITLE
Adding a bash script to check for low-commitment fee anchor channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [bosLogRawTx.service](/bosLogRawTx.service): a simple background service logging every onchain transaction and its transaction hex made by the node to republish the hex at a later time, if necessary.
 - [bosRules.service](/bosRules.service): a simple background service that enforces a rich set of rules to incoming channel requests. see description in service file what it's able to do.
 - [private-trusted-zero-conf-channels](/private-trusted-zero-conf-channels.md): short overview on how to setup private-trusted zero-conf channels between a routing node (LND) and Blixt Wallet app (neutrino-backed LND mobile node w/ enabled zero-conf channel acceptor)
+- [anchor_check.sh](/anchor_check.sh): This script shows all your channel peers anchor commit fee-rate in ascending order. Indicating risk is: with a small commitment fee in high-mempool fee environment = high, since your force-close fee won't be enough and you'll run into a CPFP for your commitment tx to get into the next 2 blocks.
 
 ___________________________________
 🏆 Credits to feelancer21, M1CH43LV, RocketNodeLN, ziggie1984 et al.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [bosLogRawTx.service](/bosLogRawTx.service): a simple background service logging every onchain transaction and its transaction hex made by the node to republish the hex at a later time, if necessary.
 - [bosRules.service](/bosRules.service): a simple background service that enforces a rich set of rules to incoming channel requests. see description in service file what it's able to do.
 - [private-trusted-zero-conf-channels](/private-trusted-zero-conf-channels.md): short overview on how to setup private-trusted zero-conf channels between a routing node (LND) and Blixt Wallet app (neutrino-backed LND mobile node w/ enabled zero-conf channel acceptor)
-- [anchor_check.sh](/anchor_check.sh): This script shows all your channel peers anchor commit fee-rate in ascending order. Indicating risk is: with a small commitment fee in high-mempool fee environment = high, since your force-close fee won't be enough and you'll run into a CPFP for your commitment tx to get into the next 2 blocks.
+- [anchor_check.sh](/anchor_check.sh): This script shows all your channel peers anchor commit fee-rate in ascending order. Indicating high risk, once you identify a small commitment fee in high-mempool fee environment. Your force-close fee won't be enough and you'll run into a CPFP for your commitment tx to get into the next 2 blocks. Mitigation might be to lower traffic with high fees and minimize rebalancing.
 
 ___________________________________
 🏆 Credits to feelancer21, M1CH43LV, RocketNodeLN, ziggie1984 et al.

--- a/anchor_check.sh
+++ b/anchor_check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Ask the user which LN system they are using
+# Check if umbrel is provided as a command-line argument
+if [[ $# -eq 1 && $1 == "umbrel" ]]; then
+    # Set the anchor_list variable for umbrel
+    anchor_list="/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli"
+else
+    # Set the anchor_list variable for any other system
+    anchor_list="lncli"
+fi
+
+# Define the list of channels sorted by total fee_per_kw ascending
+CHANNELS=$($anchor_list listchannels | jq '.channels | sort_by(.fee_per_kw | tonumber)')
+
+# Loop through each channel and extract the pubkey and fee_per_kw values
+while read -r line; do
+    # Extract the fee_per_kw and remote_pubkey values
+    FEE_PER_KW=$(echo "$line" | jq -r '.fee_per_kw')
+    PUBKEY=$(echo "$line" | jq -r '.remote_pubkey')
+
+    # Check if the pubkey is valid and get the alias name
+    ALIAS=$($anchor_list getnodeinfo --pub_key "$PUBKEY" | jq -r '.node.alias')
+    if [ -z "$ALIAS" ]; then
+      echo "Invalid node pubkey: $PUBKEY"
+      exit 1
+    fi
+
+    # Calculate the sat_vbyte value
+    SAT_VBYTE=$((FEE_PER_KW * 4 / 1000))
+
+    # Print the results
+    echo "$SAT_VBYTE sat/vb for $ALIAS ($PUBKEY)"
+done <<< "$(echo "$CHANNELS" | jq -c '.[]')"

--- a/anchor_check.sh
+++ b/anchor_check.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
-# Ask the user which LN system they are using
-# Check if umbrel is provided as a command-line argument
+#### GUIDE ###############################################
+# download this script with wget LINKTOFILE
+# assumes lncli is globally available: whereis lncli
+# execute with bash anchor_check.sh
+# For Umbrelians ☂️, add lncli alias in case you don't have it yet:
+# $ echo "alias lncli=\"/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli\"" >> ~/.bash_aliases
+# $ source ~/.bash_aliases
+
+#### One off #############################################
+# get a list of commitment fee for your peer list with this: 
+# $ lncli listchannels| jq -r '.channels | sort_by(.fee_per_kw | tonumber)[] | "\(.fee_per_kw | tonumber * 4 / 1000) sat/vb for \(.peer_alias) (\(.remote_pubkey))"' 
+# Generally a good advice to check the commitment type of your existing channels. With LND, you can get a list with
+# $ lncli listchannels | grep commitment_type
+
+
 if [[ $# -eq 1 && $1 == "umbrel" ]]; then
     # Set the anchor_list variable for umbrel
     anchor_list="/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli"

--- a/anchor_check.sh
+++ b/anchor_check.sh
@@ -33,7 +33,7 @@ while read -r line; do
     PUBKEY=$(echo "$line" | jq -r '.remote_pubkey')
 
     # Check if the pubkey is valid and get the alias name
-    ALIAS=$($anchor_list getnodeinfo --pub_key "$PUBKEY" | jq -r '.node.alias')
+    ALIAS=$($echo "$line" | jq -r '.peer_alias')
     if [ -z "$ALIAS" ]; then
       echo "Invalid node pubkey: $PUBKEY"
       exit 1

--- a/anchor_check.sh
+++ b/anchor_check.sh
@@ -4,16 +4,16 @@
 # download this script with wget LINKTOFILE
 # assumes lncli is globally available: whereis lncli
 # execute with bash anchor_check.sh
-# For Umbrelians ☂️, add lncli alias in case you don't have it yet:
-# $ echo "alias lncli=\"/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli\"" >> ~/.bash_aliases
-# $ source ~/.bash_aliases
+# For Umbrelians ☂️, execute with bash anchor_check.sh umbrel
 
 #### One off #############################################
 # get a list of commitment fee for your peer list with this: 
 # $ lncli listchannels| jq -r '.channels | sort_by(.fee_per_kw | tonumber)[] | "\(.fee_per_kw | tonumber * 4 / 1000) sat/vb for \(.peer_alias) (\(.remote_pubkey))"' 
 # Generally a good advice to check the commitment type of your existing channels. With LND, you can get a list with
 # $ lncli listchannels | grep commitment_type
-
+# Caveat: For Umbrel ☂️, you need to have lncli as an alias: 
+# $ echo "alias lncli=\"/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli\"" >> ~/.bash_aliases
+# $ source ~/.bash_aliases
 
 if [[ $# -eq 1 && $1 == "umbrel" ]]; then
     # Set the anchor_list variable for umbrel


### PR DESCRIPTION
- sort your channels with low commit fee on top
- providing a list of channels which need your intervention (eg rake up fees, lower rebalancing)
- need review of umbrel's `lncli` feasibility (had some issues earlier, need to be tested)