### PR TITLE
help command and peer filtering

### DIFF
--- a/anchor_check.sh
+++ b/anchor_check.sh
@@ -6,8 +6,9 @@
 
 #### Execute #############################################
 # execute with bash anchor_check.sh
-# To show only entries with sat/vb below N, execute with bash anchor_check.sh --filter N
+# To show only entries with sat/vb below N, execute with bash anchor_check.sh --limit N
 # For Umbrelians ☂️, execute with bash anchor_check.sh umbrel
+# To show only entries for a specific PUBKEY, execute with bash anchor_check.sh --peer PUBKEY
 
 #### One off #############################################
 # get a list of commitment fee for your peer list with this: 
@@ -18,7 +19,31 @@
 # $ echo "alias lncli=\"/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli\"" >> ~/.bash_aliases
 # $ source ~/.bash_aliases
 
-if [[ $# -eq 1 && $1 == "umbrel" ]]; then
+# Help text
+help_text="
+NAME:
+   bash anchor_check.sh - Get information on your peer's fee-commitments
+
+USAGE:
+   bash anchor_check.sh [command options]
+
+DESCRIPTION:
+   shows all your channel peers anchor commit fee-rate in ascending order.
+
+OPTIONS:
+   --peer value"$'\t\t'"limit to only one specific pubkey
+   --limit value"$'\t'"Show commitment-fee below specific limit
+   --umbrel"$'\t\t'"adjust lncli since ☂️ needs a different command call
+   -h, --help"$'\t\t'"Show this help message
+"
+
+# Check for --help option
+if [[ $1 == "--help" || $1 == "-h" ]]; then
+    echo "$help_text"
+    exit 0
+fi
+
+if [[ $# -eq 1 && $1 == "--umbrel" ]]; then
     # Set the anchor_list variable for umbrel
     anchor_list="/home/umbrel/umbrel/scripts/app compose lightning exec lnd lncli"
 else
@@ -26,9 +51,15 @@ else
     anchor_list="lncli"
 fi
 
-# Limit command line filter
-# Limit shown entries with --limit 30 to only show peers with commitment < 30 sats/vbyte
-LIMIT=$2
+# Check if --peer option is provided
+if [[ $1 == "--peer" ]]; then
+    PEER=$2
+    LIMIT=$3
+    # Get nodeinfo for the specified pubkey
+    PEER_INFO=$($anchor_list getnodeinfo --pub_key "$PEER")
+else
+    LIMIT=$2
+fi
 
 # Define the list of channels sorted by total fee_per_kw ascending
 CHANNELS=$($anchor_list listchannels | jq '.channels | sort_by(.fee_per_kw | tonumber)')
@@ -39,13 +70,24 @@ while read -r line; do
     FEE_PER_KW=$(echo "$line" | jq -r '.fee_per_kw')
     PUBKEY=$(echo "$line" | jq -r '.remote_pubkey')
 
+    # Check if --peer is provided and skip if PUBKEY does not match
+    if [[ -n "$PEER" && "$PEER" != "$PUBKEY" ]]; then
+        continue
+    fi
+
     # Check if the pubkey is valid and get the alias name
     ALIAS=$(echo "$line" | jq -r '.peer_alias')
     if [ -z "$ALIAS" ]; then
-        ALIAS=$($anchor_list getnodeinfo --pub_key \"$PUBKEY\" | jq -r '.node.alias')
-        if [ -z "$ALIAS" ]; then
-            echo "Invalid node pubkey: $PUBKEY"
-            exit 1
+        # Use the pre-fetched info if available
+        if [ -n "$PEER_INFO" ]; then
+            ALIAS=$(echo "$PEER_INFO" | jq -r '.node.alias')
+        else
+            # Fetch alias from getnodeinfo if not available
+            ALIAS=$($anchor_list getnodeinfo --pub_key "$PUBKEY" | jq -r '.node.alias')
+            if [ -z "$ALIAS" ]; then
+                echo "Invalid node pubkey: $PUBKEY"
+                exit 1
+            fi
         fi
     fi
 
@@ -53,15 +95,15 @@ while read -r line; do
     SAT_VBYTE=$((FEE_PER_KW * 4 / 1000))
 
     if [[ -z "$LIMIT" ]]; then
-      # LIMIT is empty, print everything
-      echo "$SAT_VBYTE sat/vb for $ALIAS ($PUBKEY)"
-    else
-      # LIMIT is not empty, proceed with filtering
-      if [ "$SAT_VBYTE" -lt "$LIMIT" ]; then
-        # Print everything below filter limit
+        # LIMIT is empty, print everything
         echo "$SAT_VBYTE sat/vb for $ALIAS ($PUBKEY)"
-      else
-        break
-      fi
+    else
+        # LIMIT is not empty, proceed with filtering
+        if [ "$SAT_VBYTE" -lt "$LIMIT" ]; then
+            # Print everything below filter limit
+            echo "$SAT_VBYTE sat/vb for $ALIAS ($PUBKEY)"
+        else
+            break
+        fi
     fi
 done <<< "$(echo "$CHANNELS" | jq -c '.[]')"


### PR DESCRIPTION
- added `--h` and `--help` for helptext
- adjusted `--umbrel` to be confirm with the other option calls
- added `--peer` to just show the output of commitments for one specific pubkey