### PR TITLE
introducing config.cfg file for central Telegram Bot Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.cfg

--- a/check-torpeers.sh
+++ b/check-torpeers.sh
@@ -18,8 +18,9 @@
 # 0 */3 * * * /bin/bash /home/admin/check-torpeers.sh >> /home/admin/check-torpeers.log 2>&1
 
 #Fill personal Telegram information
-TOKEN="xxx"
-CHATID="xxx"
+source ./config.cfg
+TOKEN="$TOKEN"
+CHATID="$CHATID"
 
 # define lncli command - (un)comment which applies
 # bolt/blitz installation

--- a/check-torpeers.sh
+++ b/check-torpeers.sh
@@ -17,10 +17,18 @@
 #example usage bolt setup for admin userspace -change admin to lnd if you want to run it for lnd userspace
 # 0 */3 * * * /bin/bash /home/admin/check-torpeers.sh >> /home/admin/check-torpeers.log 2>&1
 
-#Fill personal Telegram information
-source ./config.cfg
-TOKEN="$TOKEN"
-CHATID="$CHATID"
+# setup telegram bot
+# Check if the config file exists
+script_path=$(dirname "$0")
+if [ -f "$script_path/config.cfg" ]; then
+    # Source the config file if it exists
+    source $script_path/config.cfg
+else
+    # Use default values if the config file is missing
+    echo "Warning: config.cfg not found. Using default values."
+    TOKEN="YOUR_DEFAULT_TOKEN" 
+    CHATID="YOUR_DEFAULT_CHATID" 
+fi
 
 # define lncli command - (un)comment which applies
 # bolt/blitz installation

--- a/config.cfg.example
+++ b/config.cfg.example
@@ -1,0 +1,5 @@
+# rename to config.cfg and set your individual variables
+# .gitignore will ensure that those are not pushed back to the repository
+
+TOKEN="YOURBOTTOKEN"
+CHATID="YOURCHATID"

--- a/healthmonitor.sh
+++ b/healthmonitor.sh
@@ -24,8 +24,9 @@
 [ -z "$_CMD_LNCLI" ] && _CMD_LNCLI=/usr/local/bin/lncli
 
 # setup telegram bot
-TOKEN="yourtoken"
-CHATID="yourid"
+source ./config.cfg
+TOKEN="$TOKEN"
+CHATID="$CHATID"
 
 # thresholds for Telegram-notification in percent
 mem_threshold=90

--- a/healthmonitor.sh
+++ b/healthmonitor.sh
@@ -24,9 +24,17 @@
 [ -z "$_CMD_LNCLI" ] && _CMD_LNCLI=/usr/local/bin/lncli
 
 # setup telegram bot
-source ./config.cfg
-TOKEN="$TOKEN"
-CHATID="$CHATID"
+# Check if the config file exists
+script_path=$(dirname "$0")
+if [ -f "$script_path/config.cfg" ]; then
+    # Source the config file if it exists
+    source $script_path/config.cfg
+else
+    # Use default values if the config file is missing
+    echo "Warning: config.cfg not found. Using default values."
+    TOKEN="YOUR_DEFAULT_TOKEN" 
+    CHATID="YOUR_DEFAULT_CHATID" 
+fi
 
 # thresholds for Telegram-notification in percent
 mem_threshold=90

--- a/htlcScan.sh
+++ b/htlcScan.sh
@@ -16,16 +16,14 @@
 script_path=$(dirname "$0")
 if [ -f "$script_path/config.cfg" ]; then
     # Source the config file if it exists
-    echo "Good: config.cfg was found, using this one."
     source $script_path/config.cfg
 else
     # Use default values if the config file is missing
     echo "Warning: config.cfg not found. Using default values."
-    TOKEN="5546204089:AAGq4baCLw8WXVpYd7b9A7Ksl0AOuNvk5uU" 
-    CHATID="-1001720804634" 
+    TOKEN="YOUR_DEFAULT_TOKEN" 
+    CHATID="YOUR_DEFAULT_CHATID" 
 fi
 
-echo "Script started"
 # notify me if limit of pending HTLCs > X
 NOTIFYLIMIT=10
 

--- a/htlcScan.sh
+++ b/htlcScan.sh
@@ -12,9 +12,22 @@
 # version: 1.5
 
 # setup telegram bot
-source ./config.cfg
-TOKEN="$TOKEN"
-CHATID="$CHATID"
+# Check if the config file exists
+script_path=$(dirname "$0")
+if [ -f "$script_path/config.cfg" ]; then
+    # Source the config file if it exists
+    echo "Good: config.cfg was found, using this one."
+    source $script_path/config.cfg
+else
+    # Use default values if the config file is missing
+    echo "Warning: config.cfg not found. Using default values."
+    TOKEN="5546204089:AAGq4baCLw8WXVpYd7b9A7Ksl0AOuNvk5uU" 
+    CHATID="-1001720804634" 
+fi
+
+echo "Script started"
+# notify me if limit of pending HTLCs > X
+NOTIFYLIMIT=10
 
 # define lncli command - (un)comment which applies
 # bolt/blitz installation
@@ -84,7 +97,7 @@ htlc_list=$(echo $listchannels | jq -r  ".channels[] | .pending_htlcs[] | select
 if [ -z "$htlc_list" ]; then
   echo "$(date "+%Y-%m-%d %H:%M:%S") no htlc(s) found with expiration < $blocks_til_expiry blocks"
   numhtlcs=$(echo $listchannels | jq -r  ".channels[] | .pending_htlcs[] | select(.expiration_height) | .hash_lock" | wc -l)
-  [[ "$numhtlcs" -gt 9 ]] && pushover "No critical htlcs found.\n$numhtlcs pending htlc(s)"
+  [[ "$numhtlcs" -gt $NOTIFYLIMIT ]] && pushover "No critical htlcs found.\n$numhtlcs pending htlc(s)"
   exit 0
 fi
 

--- a/htlcScan.sh
+++ b/htlcScan.sh
@@ -12,8 +12,9 @@
 # version: 1.5
 
 # setup telegram bot
-TOKEN="YOURBOTTOKEN"
-CHATID="YOURCHATID"
+source ./config.cfg
+TOKEN="$TOKEN"
+CHATID="$CHATID"
 
 # define lncli command - (un)comment which applies
 # bolt/blitz installation


### PR DESCRIPTION
- added `config.cfg.example` which is supposed to be renamed to `config.cfg`
- add your Telegram Bot ID and your chat-id once in this file
- the three scripts leveraging send-message to Telegram Bot will use those 

Removes overhead and simplifies the clone of the whole directory